### PR TITLE
docs: link CONTRIBUTORS.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ This creates several `.pcap` files simulating YouTube, ChatGPT, and other traffi
 
 **Rahul Kumar** — [github.com/rahul05au](https://github.com/rahul05au)
 
+See the full list of contributors in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ---
 
 ## 🤝 Contributing


### PR DESCRIPTION
Links the CONTRIBUTORS.md file in the main README's Author section for better visibility.